### PR TITLE
Bypass charging support for Lenovo Xiaoxin Pad 2024

### DIFF
--- a/archdaemon/jni/src/BinaryCLI/BypassCompatibility.c
+++ b/archdaemon/jni/src/BinaryCLI/BypassCompatibility.c
@@ -66,6 +66,9 @@ int check_bypass_compatibility() {
             printf("\033[32m[INFO]\033[0m Process finished. %d nodes skipped.\n", skipped_count);
 
             log_zenith(LOG_INFO, "Compatible path found: %s. Skipped: %d", bypass_list[i].name, skipped_count);
+
+            __system_property_set("persist.sys.azenithconf.bypasspath", bypass_list[i].name);
+            systemv("echo %s > %s/bypasspath", bypass_list[i].name, BYPASSCHG_CONFIG);
             return 0;
         } else {
             printf("\033[31m[FAILED]\033[0m Current drop test failed for %s (%d mA)\n", bypass_list[i].name, last_ma);

--- a/archdaemon/jni/src/BinaryCLI/BypassCompatibility.c
+++ b/archdaemon/jni/src/BinaryCLI/BypassCompatibility.c
@@ -67,8 +67,6 @@ int check_bypass_compatibility() {
 
             log_zenith(LOG_INFO, "Compatible path found: %s. Skipped: %d", bypass_list[i].name, skipped_count);
 
-            __system_property_set("persist.sys.azenithconf.bypasspath", bypass_list[i].name);
-            systemv("echo %s > %s/bypasspath", bypass_list[i].name, BYPASSCHG_CONFIG);
             return 0;
         } else {
             printf("\033[31m[FAILED]\033[0m Current drop test failed for %s (%d mA)\n", bypass_list[i].name, last_ma);

--- a/archdaemon/jni/src/BypassCharge/ChargingNodes.c
+++ b/archdaemon/jni/src/BypassCharge/ChargingNodes.c
@@ -50,10 +50,11 @@ BypassNode bypass_list[] = {
     {"I2C_CHG_ENABLE", "/sys/devices/platform/omap/omap_i2c.3/i2c-3/3-005f/charge_enable", "0", "1"},
     {"QPNP_SMB_BATT_EN", "/sys/devices/soc/qpnp-smbcharger-18/power_supply/battery/battery_charging_enabled", "0", "1"},
 
-    {"QCOM_SUSPEND", "/sys/class/qcom-battery/input_suspend", "0", "1"},
+    {"QCOM_SUSPEND", "/sys/class/qcom-battery/input_suspend", "1", "0"},
     {"QCOM_EN_CHG", "/sys/class/qcom-battery/charging_enabled", "0", "1"},
     {"QCOM_COOL_MODE", "/sys/class/qcom-battery/cool_mode", "1", "0"},
     {"QCOM_PROTECT_EN", "/sys/class/qcom-battery/batt_protect_en", "1", "0"},
+    {"QCOM_BATT_PROTECTED", "/sys/class/qcom-battery/battery_protected", "1", "0"},
     {"QCOM_PMIC_GLINK_SUSPEND",
      "/sys/devices/platform/soc/soc:qcom,pmic_glink/soc:qcom,pmic_glink:qcom,battery_charger/"
      "force_charger_suspend",


### PR DESCRIPTION
Adds `/sys/class/qcom-battery/battery_protected` to `bypass_list[]`. On this
platform `batt_protect_en` / `charging_enabled` / `cool_mode` don't exist, so no
true-bypass node was detected.

Two things blocked it, fixed here as well:

- `QCOM_SUSPEND` polarity is inverted — it's the only `input_suspend` entry
  declared `"0", "1"`. Since `check_bypass_compatibility()` restores each node
  with `off_val`, its test *ends* by suspending the charger input, breaking
  detection of every node after it.
- `check_bypass_compatibility()` never stores the node it finds; only the
  failure path writes `persist.sys.azenithconf.bypasspath`.

Verified on hardware (TB331FC, ZUI 16 / Android 14, KernelSU) with a build from
this branch: `battery_protected 1` gives `current_now` 0 µA with no drain, and
`--checkbypasschg` now selects it.
